### PR TITLE
Updated collections with collections.abc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 The scan result parsed by [libnmap.parser.NmapParser](https://libnmap.readthedocs.io/en/latest/parser.html#module-libnmap.parser), so [python-libnmap](https://pypi.org/project/python-nmap/) is required. and the parsed-result is [libnmap.objects.NmapReport](https://libnmap.readthedocs.io/en/latest/objects/nmapreport.html). 
 
 ### PortScanner
-A port scanner seem to python-nmap PortScanner. It is run in a process and wait until process exit with **yield from** or **await**.
+A port scanner similar to python-nmap PortScanner. It is run in a process and wait until process exit with **yield from** or **await**.
 eg:
 ```python
 import aionmap
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     loop.run_until_complete(main())
 ```
 ### PortScannerYield
-A port scanner seem to python-nmap PortScannerYield,  but **async for** instead. It can only run with environment where Python  version greater than 3.5. The scanner run with multi processes at the same time, default is 3 processes, you can control it by argument **batch_count** when call function **PortScannerYield.scan**.
+A port scanner similar to python-nmap PortScannerYield,  but **async for** instead. It can only run with environment where Python  version greater than 3.5. The scanner run with multi processes at the same time, default is 3 processes, you can control it by argument **batch_count** when call function **PortScannerYield.scan**.
 eg:
 ```python
 import asyncio

--- a/aionmap/__init__.py
+++ b/aionmap/__init__.py
@@ -1,5 +1,5 @@
 import asyncio
-import collections
+import collections.abc
 import os
 import re
 import shlex
@@ -144,8 +144,8 @@ class PortScannerBase(object):
         )
         
     def _get_scan_args(self, hosts, ports, arguments):
-        assert isinstance(hosts, (str, collections.Iterable)), 'Wrong type for [hosts], should be a string or Iterable [was {0}]'.format(type(hosts))
-        assert isinstance(ports, (str, collections.Iterable, type(None))), 'Wrong type for [ports], should be a string or Iterable [was {0}]'.format(type(ports))  # noqa
+        assert isinstance(hosts, (str, collections.abc.Iterable)), 'Wrong type for [hosts], should be a string or Iterable [was {0}]'.format(type(hosts))
+        assert isinstance(ports, (str, collections.abc.Iterable, type(None))), 'Wrong type for [ports], should be a string or Iterable [was {0}]'.format(type(ports))  # noqa
         assert isinstance(arguments, str), 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))  # noqa
         
         if not isinstance(hosts, str):


### PR DESCRIPTION
It looks like the "Iterable" object can no longer be called upon with "collections.Iterable".  Instead, the team moved it into the "Abstract Base Classes" https://docs.python.org/3/library/abc.html.  

As such, the current master branch is broken out of the box (fails in Line 147 of __init__.py here: https://github.com/ranyixu/aionmap/blob/7d40591cd052f36d09d68665328ff2418a83ee1e/aionmap/__init__.py#L147).  

I made two minor changes:
    1) fixed the functionality of the module by changing "collections" to "collections.abc"
    2) changed two verbs in the README.md because they were confusing.  

Great project!